### PR TITLE
CI hardening: disable DLC, make codecov upload non-blocking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,11 @@ commands:
         type: string
     steps:
       - run:
-          name: Upload codecov
+          name: Upload codecov (non-blocking)
           command: |
+            # Coverage upload is observability, not a release gate. Don't fail
+            # the deploy if keybase/codecov/uploader.codecov.io has a blip.
+            set +e
             curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
@@ -20,6 +23,7 @@ commands:
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x codecov
             ./codecov <<parameters.test>>
+            exit 0
 
 defaults:
   - &settings
@@ -42,7 +46,11 @@ jobs:
   build:
     machine:
       image: ubuntu-2004:2023.04.2
-      docker_layer_caching: true
+      # DLC turned off: persistent cache corruption blocks deploys with
+      # "failed to compute cache key: parent snapshot ... does not exist".
+      # Matches the same setting in flowminder-gcp-mobility-dashboard and
+      # the flowkit-ui repo (after its PR #67).
+      docker_layer_caching: false
     resource_class: large
     working_directory: /tmp/flowkit-ui-backend
     steps:


### PR DESCRIPTION
## Summary
Mirror of flowkit-ui PR #67 — this repo has its own copy of the same fragile codecov command and same DLC setting, both of which have blocked deploys today (PR #30's CI failed at the codecov step on a green test pass).

### 1. Docker Layer Caching off
Persistent cache corruption fails docker build with \`failed to compute cache key: parent snapshot ... does not exist\`. Builds get marginally slower with DLC off but become reliable. Matches \`flowminder-gcp-mobility-dashboard\` (which has this exact setting with a comment explaining the same root cause) and \`flowkit-ui\` after its #67.

### 2. Codecov upload non-blocking
The codecov command does six external network calls before the actual upload (keybase PGP key, uploader downloads, GPG verify, SHA verify). Any one failing kills the build job, which skips \`update-mob-dashtag\`, which blocks the deploy. Coverage upload is observability, not a release gate. Wrap with \`set +e\` / \`exit 0\` so transient blips log but don't fail the pipeline.

## Test plan
- [ ] Merge and watch the auto-deploy chain run cleanly.
- [ ] Confirm in CircleCI the codecov step either succeeds or logs failure without failing the job.