### PR TITLE
Add bins config for the four raw/diff flow indicators

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -219,7 +219,14 @@
             "scale": "sequential",
             "decimals": 2,
             "min_value": 0,
-            "max_value": null
+            "max_value": null,
+            "bins": [
+                { "min": 0, "max": 50, "width": "2%" },
+                { "min": 50, "max": 200, "width": "10%" },
+                { "min": 200, "max": 500, "width": "25%" },
+                { "min": 500, "max": 2000, "width": "50%" },
+                { "min": 2000, "max": null, "width": "80%" }
+            ]
         },
         {
             "category_id": "relocations",
@@ -235,7 +242,18 @@
             "scale": "diverging",
             "decimals": 0,
             "min_value": null,
-            "max_value": null
+            "max_value": null,
+            "bins": [
+                { "min": -25, "max": 25, "width": "2%" },
+                { "min": -100, "max": -25, "width": "10%" },
+                { "min": 25, "max": 100, "width": "10%" },
+                { "min": -300, "max": -100, "width": "25%" },
+                { "min": 100, "max": 300, "width": "25%" },
+                { "min": -1000, "max": -300, "width": "50%" },
+                { "min": 300, "max": 1000, "width": "50%" },
+                { "min": null, "max": -1000, "width": "80%" },
+                { "min": 1000, "max": null, "width": "80%" }
+            ]
         },
         {
             "category_id": "relocations",
@@ -415,7 +433,14 @@
             "scale": "sequential",
             "decimals": 0,
             "min_value": 0,
-            "max_value": null
+            "max_value": null,
+            "bins": [
+                { "min": 0, "max": 50, "width": "2%" },
+                { "min": 50, "max": 500, "width": "10%" },
+                { "min": 500, "max": 2000, "width": "25%" },
+                { "min": 2000, "max": 10000, "width": "50%" },
+                { "min": 10000, "max": null, "width": "80%" }
+            ]
         },
         {
             "category_id": "movements",
@@ -431,7 +456,18 @@
             "scale": "diverging",
             "decimals": 0,
             "min_value": null,
-            "max_value": null
+            "max_value": null,
+            "bins": [
+                { "min": -50, "max": 50, "width": "2%" },
+                { "min": -500, "max": -50, "width": "10%" },
+                { "min": 50, "max": 500, "width": "10%" },
+                { "min": -2000, "max": -500, "width": "25%" },
+                { "min": 500, "max": 2000, "width": "25%" },
+                { "min": -10000, "max": -2000, "width": "50%" },
+                { "min": 2000, "max": 10000, "width": "50%" },
+                { "min": null, "max": -10000, "width": "80%" },
+                { "min": 10000, "max": null, "width": "80%" }
+            ]
         },
         {
             "category_id": "movements",


### PR DESCRIPTION
## Summary
Brings `resources/config.json` into alignment with the bins that have already been applied to both dev and prod MySQL for the remaining four flow indicators.

PR #30 added the bins for the two `*_pctchangewithref` flow indicators. Since then, the other four have been tuned via direct SQL on dev (and subsequently mirrored to prod), but `config.json` was never updated.

## What this commit does
Adds the `bins` JSON array to these four indicator entries in `resources/config.json`:

| Indicator | Bins | Type |
|---|---|---|
| `relocations.relocations` | 5-tier 2/10/25/50/80%, thresholds 0/50/200/500/2000 | sequential |
| `relocations.relocations_diffwithref` | 9-tier diverging, ±25/100/300/1000 | diverging |
| `movements.travellers` | 5-tier 2/10/25/50/80%, thresholds 0/50/500/2000/10000 | sequential |
| `movements.travellers_diffwithref` | 9-tier diverging, ±50/500/2000/10000 | diverging |

## Why no DB migration
Per the `bins-not-runtime` convention: `config.json` is a seed template, not loaded at runtime. The dashboard reads bins from the `indicator` table in MySQL. Both environments already have these bins applied, so merging this PR doesn't change runtime behavior — it just makes the source-of-truth file accurate for future fresh DB setups and for documentation purposes.

## Verification
Bins added match exactly what's currently in `flowkit_ui_backend.indicator.bins` on both `mobdash-sql-dev` and `mobdash-sql-prod`. Verified by running:
```sql
SELECT indicator_id, JSON_EXTRACT(bins, "$") FROM indicator WHERE indicator_id IN (...);
```
on both environments and confirming the JSON matches.

## Test plan
- [ ] CI green
- [ ] JSON validates